### PR TITLE
Fix "random" type and simplify model __new__

### DIFF
--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -6,13 +6,13 @@ Core Objects: Agent
 
 """
 # mypy
-from typing import Any
-if False:
-    from .model import Model
+from .model import Model
+from random import Random
 
 
 class Agent:
     """ Base class for a model agent. """
+
     def __init__(self, unique_id: int, model: Model) -> None:
         """ Create a new agent. """
         self.unique_id = unique_id
@@ -27,5 +27,5 @@ class Agent:
         pass
 
     @property
-    def random(self) -> Any:
+    def random(self) -> Random:
         return self.model.random

--- a/mesa/model.py
+++ b/mesa/model.py
@@ -5,8 +5,8 @@ The model class for Mesa framework.
 Core Objects: Model
 
 """
-import time
 import random
+
 # mypy
 from typing import Any, Optional
 
@@ -16,13 +16,9 @@ class Model:
 
     def __new__(cls, *args: Any, **kwargs: Any) -> Any:
         """Create a new model object and instantiate its RNG automatically."""
-
-        model = object.__new__(cls)  # This only works in Python 3.3 and above
-        model._seed = time.time()
-        if "seed" in kwargs and kwargs["seed"] is not None:
-            model._seed = kwargs["seed"]
-        model.random = random.Random(model._seed)
-        return model
+        cls._seed = kwargs.get("seed", None)
+        cls.random = random.Random(cls._seed)
+        return object.__new__(cls)
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """ Create a new model. Overload this method with the actual code to

--- a/mesa/time.py
+++ b/mesa/time.py
@@ -27,8 +27,7 @@ from collections import OrderedDict
 # mypy
 from typing import Dict, Iterator, List, Optional, Union
 from .agent import Agent
-if False:
-    from .model import Model
+from .model import Model
 
 
 # BaseScheduler has a self.time of int, while


### PR DESCRIPTION
Some proposed fixes for the errors. I changed the models `__new__` to a simplified version, where `._seed` and `.random` are recognized by mypy. 

Question: You had some code blocks like this
```python
if False:
    from .model import Model
```

I know this is for circular references and I remember having those as well when working with mypy earlier, but I just changed them to regular imports and it seems to work. Can you maybe clarify under what circumstances this might break? 

Also note that it is now recommended to use 
```python
from typing import TYPE_CHECKING
if TYPE_CHECKING: 
    ...
```